### PR TITLE
manage container via podman api

### DIFF
--- a/podman_variables.py
+++ b/podman_variables.py
@@ -1,0 +1,35 @@
+#!/usr/bin/python3
+
+import os
+
+def create_mounts_dict(host_mount, container_mount, read_only=False, selinux_label=True, selinux_recursive=True):
+# if selinux_label=True the container_file_t label will be applied to the source host directory
+# it can be set to False if the directory exists on an nfs mount and has the nfs_t label set
+# if selinux_recursive=True (and selinux_label=True) the container_file_t label will be recursively applied to the source host directory
+
+    mounts = {
+               'type':              'bind',
+               'source':            host_mount,
+               'target':            container_mount,
+               'read_only':         read_only,
+               'selinux_label':     selinux_label,
+               'selinux_recursive': selinux_recursive
+             }
+
+    return mounts
+
+
+cur_dir                 = os.path.dirname(os.path.realpath(__file__))
+bind_volumes            = []
+
+image_name              = 'cross_build_env'
+container_name          = 'cross_builder'
+container_hostname      = 'cross_builder'
+
+output_dir_host         = f'{cur_dir}/output'
+output_dir_container    = '/output'
+
+bind_volumes.append(create_mounts_dict(output_dir_host, output_dir_container))
+
+# set privileged mode
+privileged = False

--- a/script-podman.py
+++ b/script-podman.py
@@ -1,0 +1,339 @@
+#!/usr/bin/python3
+
+import argparse
+import os
+import rpm
+import selinux
+import subprocess
+import sys
+from podman import PodmanClient
+from termcolor import cprint
+
+# import podman variables from local file
+sys.dont_write_bytecode = True
+from podman_variables import *
+
+
+def print_yes():
+    cprint(' [YES]', 'green')
+
+
+def print_no():
+    cprint(' [NO]', 'red')
+
+
+def print_soft_no():
+    cprint(' [NO]', 'yellow', attrs=['bold','dark'])
+
+
+def print_success():
+    cprint(' [SUCCESS]', 'green')
+
+
+def print_failure():
+    cprint(' [FAILURE]', 'red')
+
+
+def print_debug(msg, cmd):
+    cprint(f'DEBUG: {msg}:', 'yellow')
+    cprint(f'{cmd}\n', 'yellow', attrs=['bold'])
+
+
+def check_podman_installed():
+    cprint('{0:.<70}'.format('PODMAN: is podman installed'), 'yellow', end='')
+    podman_installed = None
+    ts = rpm.TransactionSet()
+    rpm_listing = ts.dbMatch()
+
+    for rpm_pkg in rpm_listing:
+        if rpm_pkg['name'] == 'podman':
+            podman_installed = True
+
+    if podman_installed:
+        print_yes()
+    else:
+        print_no()
+        cprint('\npodman is not installed', 'magenta')
+        cprint('Exiting...', 'red')
+        sys.exit(1)
+
+
+def ensure_podman_socket_running():
+    if os.geteuid() == 0:
+        user = ''
+    else:
+        user = '--user '
+
+    cmd_str = f'systemctl {user} is-active --quiet podman.socket'
+    cmd = cmd_str.split()
+    cmd_output = subprocess.run(cmd)
+
+    if cmd_output.returncode == 0:
+        return
+
+    cprint('PODMAN: starting podman.socket...', 'yellow')
+
+    cmd_str = f'systemctl {user}start podman.socket'
+    cmd = cmd_str.split()
+    cmd_output = subprocess.run(cmd, capture_output=True, universal_newlines=True)
+
+    if args.debug:
+        print_debug('to manually start podman.socket', cmd_str)
+
+    if cmd_output.returncode != 0:
+        err_output = cmd_output.stderr.rstrip()
+        cprint(err_output, 'red', attrs=['bold'])
+        sys.exit(2)
+
+
+def ensure_image_exists():
+    cprint('{0:.<70}'.format('PODMAN: checking if image exists'), 'yellow', end='')
+    podman_image = client.images.list(filters = {'reference' : image_name})
+
+    if podman_image:
+        print_yes()
+    else:
+        print_soft_no()
+        cprint('PODMAN: building image...', 'yellow')
+        # using the api function will hide the build process
+        # use subprocess so we can see it in real-time
+        # client.images.build(path=cur_dir, tag=image_name, squash=True, rm=True)
+        podman_cmd_str = f'podman build --squash -t {image_name} {cur_dir}'
+        podman_cmd = podman_cmd_str.split()
+
+        if args.debug:
+            print_debug('to manually build the image', podman_cmd_str)
+
+        cmd_output = subprocess.run(podman_cmd, universal_newlines=True)
+        cprint('{0:.<70}'.format('PODMAN: build image'), 'yellow', end='')
+
+        if cmd_output.returncode != 0:
+            print_failure()
+            cprint('Exiting...', 'red')
+            sys.exit(3)
+        else:
+            print_success()
+
+
+def ensure_image_removed():
+    cprint('{0:.<70}'.format('PODMAN: checking if image exists'), 'yellow', end='')
+    podman_image_exists = client.images.list(filters = {'reference' : image_name})
+
+    if podman_image_exists:
+        print_yes()
+        cprint('PODMAN: removing image...', 'yellow')
+        client.images.remove(image=image_name)
+    else:
+        print_soft_no()
+
+
+def ensure_container_exists_and_running():
+    cprint('{0:.<70}'.format('PODMAN: checking if container exists'), 'yellow', end='')
+    container_exists = client.containers.list(all=True, filters = {'name' : container_name})
+
+    if container_exists:
+        print_yes()
+        podman_container = client.containers.get(container_name)
+        container_status = podman_container.status
+
+        cprint('{0:.<70}'.format('PODMAN: checking if container is running'), 'yellow', end='')
+
+        if container_status == 'running':
+            print_yes()
+            return
+        else:
+            print_soft_no()
+            cprint('PODMAN: starting container...', 'yellow')
+            if args.debug:
+                print_debug('to manually start the container', f'podman start {container_name}')
+            podman_container.start()
+            ensure_container_exists_and_running()
+    else:
+        print_soft_no()
+        run_container()
+        ensure_container_exists_and_running()
+
+
+def ensure_container_stopped_removed(remove_container=True):
+    cprint('{0:.<70}'.format('PODMAN: checking if container exists'), 'yellow', end='')
+    container_exists = client.containers.list(all=True, filters = {'name' : container_name})
+
+    if container_exists:
+        print_yes()
+        podman_container = client.containers.get(container_name)
+        container_status = podman_container.status
+
+        cprint('{0:.<70}'.format('PODMAN: checking if container is running'), 'yellow', end='')
+
+        if container_status == 'running':
+            print_yes()
+            cprint('PODMAN: stopping container...', 'yellow')
+            if args.debug:
+                print_debug('to manually stop the container', f'podman stop {container_name}')
+            podman_container.stop()
+            if remove_container:
+                # in the event that auto-remove is set the container may already be deleted
+                ensure_container_stopped_removed(remove_container)
+                return
+        else:
+            print_soft_no()
+
+        if remove_container:
+            cprint('PODMAN: removing container...', 'yellow')
+            if args.debug:
+                print_debug('to manually remove the container', f'podman rm {container_name}')
+            podman_container.remove()
+    else:
+        print_soft_no()
+
+
+def set_selinux_context_t():
+    container_context_t = 'container_file_t'
+    dir_file_paths = []
+
+    for vol in bind_volumes:
+        host_dir = None
+        recursive = None
+
+        if vol['selinux_label']:
+            host_dir = vol['source']
+            recursive = vol['selinux_recursive']
+
+            if not recursive:
+                dir_file_paths.append(host_dir)
+            else:
+                for dir_path, dirs, files in os.walk(host_dir):
+                    for filename in files:
+                        file_path = os.path.join(dir_path,filename)
+                        dir_file_paths.append(file_path)
+
+                    dir_file_paths.append(dir_path)
+
+    if not dir_file_paths:
+        return
+
+    cprint('{0:.<70}'.format('PODMAN: selinux label check'), 'yellow', end='')
+
+    for dir_file_path in dir_file_paths:
+        ret, mount_dir_context = selinux.getfilecon(dir_file_path)
+
+        if ret < 0:
+            print_failure()
+            cprint(f'selinux.getfilecon({dir_file_path}) failed....exiting', red)
+            sys.exit(4)
+
+        mount_dir_context_t = mount_dir_context.split(':')[2]
+        if mount_dir_context_t != container_context_t:
+            mount_dir_context = mount_dir_context.replace(mount_dir_context_t, container_context_t)
+            selinux.setfilecon(dir_file_path, mount_dir_context)
+
+    print_yes()
+
+
+def create_podman_vol_str():
+    mount_vol_list = []
+
+    if not bind_volumes:
+        return ''
+
+    for vol in bind_volumes:
+        option = ''
+        if vol['read_only']:
+            option = ':ro'
+        mount_vol_list.append(f"-v {vol['source']}:{vol['target']}{option} ")
+
+    mount_vol_str = ''.join(mount_vol_list).rstrip()
+
+    return mount_vol_str
+
+
+def run_container():
+    if selinux.is_selinux_enabled():
+        set_selinux_context_t()
+
+    cprint('PODMAN: run container...', 'yellow')
+    podman_vol_str = create_podman_vol_str()
+
+    if privileged:
+        privileged_str = '--privileged '
+    else:
+        privileged_str = ''
+
+    podman_cmd_str = f'podman run -d -it {privileged_str}{podman_vol_str} -h {container_hostname} --name {container_name} {image_name}'
+    if args.debug:
+        print_debug('to manually run the container', podman_cmd_str)
+
+    client.containers.run(image=image_name, name=container_name, hostname=container_hostname, detach=True, tty=True, privileged=privileged, mounts=bind_volumes)
+
+
+if __name__ == "__main__":
+
+    parser = argparse.ArgumentParser()
+    group = parser.add_mutually_exclusive_group()
+
+    parser.add_argument('--debug',
+                        action='store_true',
+                        help='display debug messages',
+                        default=False)
+    group.add_argument('--rebuild',
+                        action='store_true',
+                        help='remove podman image and container if they exist, '
+                             'then build (new) podman image and run container',
+                        default=False)
+    group.add_argument('--rerun',
+                        action='store_true',
+                        help='remove container if it exists, then (re-)run it',
+                        default=False)
+    group.add_argument('--restart',
+                        action='store_true',
+                        help='stop the container if it exists, then (re-)run it',
+                        default=False)
+    group.add_argument('--rm_image',
+                        action='store_true',
+                        help='remove podman image and container if they exist',
+                        default=False)
+    group.add_argument('--rm_container',
+                        action='store_true',
+                        help='remove container if it exists',
+                        default=False)
+    group.add_argument('--stop_container',
+                        help='stop podman container it exists and is running',
+                        action='store_true',
+                        default=False)
+
+    args = parser.parse_args()
+
+    check_podman_installed()
+    ensure_podman_socket_running()
+
+    if os.geteuid() == 0:
+        client = PodmanClient(base_url='unix:/run/podman/podman.sock')
+    else:
+        client = PodmanClient()
+
+    if args.rm_image or args.rebuild:
+        ensure_container_stopped_removed()
+        ensure_image_removed()
+        if args.rm_image: sys.exit()
+
+    if args.rm_container or args.rerun:
+        ensure_container_stopped_removed()
+        if args.rm_container: sys.exit()
+
+    if args.stop_container or args.restart:
+        ensure_container_stopped_removed(remove_container=False)
+        if args.stop_container: sys.exit()
+
+
+    cprint('{0:.<70}'.format('PODMAN: image name'), 'yellow', end='')
+    cprint(f' {image_name}', 'cyan')
+
+    ensure_image_exists()
+
+    cprint('{0:.<70}'.format('PODMAN: container name'), 'yellow', end='')
+    cprint(f' {container_name}', 'cyan')
+
+    ensure_container_exists_and_running()
+
+    cprint('PODMAN: to login to the container run:', 'yellow')
+    cprint(f'podman exec -it {container_name} /bin/bash\n', 'green')


### PR DESCRIPTION
Please don't feel the need to merge this PR. I'm just wanted to show you this concept I've been working on.
I stumbled across your git project today and thought you might find this useful.

So this is a concept I've been working on lately where you use a python script on automate the management of a podman image and container. 

```
[leif.liddy@black cs9-cross-gcc]$ ./script-podman.py --help
usage: script-podman.py [-h] [--debug]
                        [--rebuild | --rerun | --restart | --rm_image | --rm_container | --stop_container]

options:
  -h, --help        show this help message and exit
  --debug           display debug messages
  --rebuild         remove podman image and container if they exist, then build (new) podman image and run container
  --rerun           remove container if it exists, then (re-)run it
  --restart         stop the container if it exists, then (re-)run it
  --rm_image        remove podman image and container if they exist
  --rm_container    remove container if it exists
  --stop_container  stop podman container it exists and is running
```

You literally just run `./script-podman.py` and it will build the image and run the container by default.   
The script arguments should be pretty self-explanatory. 

You just need to following packages installed on the host system.
```dnf install podman python3-podman python3-termcolor```

These are the package names for Fedora, not sure if they differ for Centos. 

The `podman_variables.py` file contains the image name, container name...etc
as well as which directories to mount from the host system to the container. 
Currently the `./output` directory will be mounted from the host system and will be mounted under `/output` inside the container. You can obviously add more shared directories if needed. 
Before you run `./script-podman.py` just make sure to run `mkdir output` first to create the host system `output` directory.

Either that, or comment out these three lines in the `podman_variables.py` file   
```
output_dir_host         = f'{cur_dir}/output'
output_dir_container    = '/output'
bind_volumes.append(create_mounts_dict(output_dir_host, output_dir_container))
```

In any case it's something you can at least try out and see if you like it or not.   
If it's not for you....it's all good ; )

BTW, I didn't realize that you could call the config `Containerfile`   
I've been calling it `Dockerfile` for ages.   
Cool....now I'm going to rename `Dockerfile` --> `Containerfile` in all my projects that use this python api script : )